### PR TITLE
Fix authorization error

### DIFF
--- a/app/code/community/Netresearch/Epayments/Model/Config.php
+++ b/app/code/community/Netresearch/Epayments/Model/Config.php
@@ -70,20 +70,6 @@ class Netresearch_Epayments_Model_Config implements Netresearch_Epayments_Model_
     const CONFIG_INGENICO_SYSTEM_PREFIX = 'ingenico_epayments/settings/system_prefix';
 
     /**
-     * @var Mage_Core_Model_Encryption
-     */
-    private $encryptor;
-
-    /**
-     * Netresearch_Epayments_Model_Config constructor.
-     */
-    public function __construct()
-    {
-        $this->encryptor = Mage::getModel('core/encryption');
-    }
-
-
-    /**
      * @param int $storeId
      * @return string
      */
@@ -113,9 +99,7 @@ class Netresearch_Epayments_Model_Config implements Netresearch_Epayments_Model_
      */
     public function getApiSecret($storeId = null)
     {
-        return $this->encryptor->decrypt(
-            Mage::getStoreConfig(self::CONFIG_INGENICO_API_SECRET, $storeId)
-        );
+        return Mage::getStoreConfig(self::CONFIG_INGENICO_API_SECRET, $storeId);
     }
 
     /**
@@ -181,9 +165,7 @@ class Netresearch_Epayments_Model_Config implements Netresearch_Epayments_Model_
      */
     public function getWebhooksSecretKey($storeId = null)
     {
-        return $this->encryptor->decrypt(
-            Mage::getStoreConfig(self::CONFIG_INGENICO_WEBHOOKS_SECRET_KEY, $storeId)
-        );
+        return Mage::getStoreConfig(self::CONFIG_INGENICO_WEBHOOKS_SECRET_KEY, $storeId);
     }
 
     /**
@@ -199,9 +181,7 @@ class Netresearch_Epayments_Model_Config implements Netresearch_Epayments_Model_
      */
     public function getSecondaryWebhooksSecretKey($storeId = null)
     {
-        return $this->encryptor->decrypt(
-            Mage::getStoreConfig(self::CONFIG_INGENICO_WEBHOOKS_SECRET_KEY_SECONDARY, $storeId)
-        );
+        return Mage::getStoreConfig(self::CONFIG_INGENICO_WEBHOOKS_SECRET_KEY_SECONDARY, $storeId);
     }
 
     /**

--- a/app/code/community/Netresearch/Epayments/etc/config.xml
+++ b/app/code/community/Netresearch/Epayments/etc/config.xml
@@ -222,6 +222,9 @@
                 <title>Ingenico ePayments</title>
             </general>
             <settings>
+                <api_secret backend_model="adminhtml/system_config_backend_encrypted" />
+                <secret_key backend_model="adminhtml/system_config_backend_encrypted" />
+                <secret_key_secondary backend_model="adminhtml/system_config_backend_encrypted" />
                 <hosted_checkout_subdomain>https://payment.</hosted_checkout_subdomain>
                 <log_all_requests>0</log_all_requests>
                 <log_all_requests_file>ingenico_epayments.log</log_all_requests_file>


### PR DESCRIPTION
Implicit description of encrypted values from the `core_config_data` table is not needed, because it's done by Magento behind the scenes thanks to `backend_model` specified for configuration fields in `system.xml` file.